### PR TITLE
Add CODEOWNERS file for AI app compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# TODO: Replace with domain-specific team
+* @alchemyplatform/alchemy-engineers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # TODO: Replace with domain-specific team
-* @alchemyplatform/alchemy-engineers
+* @alchemyplatform/engineering


### PR DESCRIPTION
> **WARNING:** Using org-wide fallback team - replace with domain-specific team when identified.

Adds CODEOWNERS requiring human review from: **@alchemyplatform/alchemy-engineers**

**Why:** AI apps removed due to lack of CODEOWNERS ([PR #505](https://github.com/OMGWINNING/terraform-github/pull/505), [#503](https://github.com/OMGWINNING/terraform-github/pull/503)). Without CODEOWNERS, AI bots can self-approve PRs.

**Selection:** Fallback to org-wide engineers team (no domain-specific team identified)

**To regain AI access:**
1. Merge this PR
2. Enable branch protection: Settings → Branches → "Require review from Code Owners"
3. Request re-enablement via [terraform-github](https://github.com/OMGWINNING/terraform-github)

[Compliance report](https://gist.github.com/mjbenedict-alchemy/2b55685bb5f018db89bcd636616e4157) | Contact: @michael.benedict or #cloud-infra-reviews